### PR TITLE
feat(5851/iox-11168): memory usage vs encoding size for ArrowWriter

### DIFF
--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -330,6 +330,10 @@ impl DictEncoder {
         num_required_bits(length.saturating_sub(1) as u64)
     }
 
+    fn estimated_memory_size(&self) -> usize {
+        self.interner.storage().page.len() + self.indices.len() * 8
+    }
+
     fn estimated_data_page_size(&self) -> usize {
         let bit_width = self.bit_width();
         1 + RleEncoder::max_buffer_size(bit_width, self.indices.len())
@@ -437,6 +441,13 @@ impl ColumnValueEncoder for ByteArrayEncoder {
 
     fn has_dictionary(&self) -> bool {
         self.dict_encoder.is_some()
+    }
+
+    fn estimated_memory_size(&self) -> usize {
+        match &self.dict_encoder {
+            Some(encoder) => encoder.estimated_memory_size(),
+            None => self.fallback.estimated_data_page_size(),
+        }
     }
 
     fn estimated_dict_page_size(&self) -> Option<usize> {

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2826,6 +2826,7 @@ mod tests {
         // starts empty
         assert_eq!(writer.in_progress_size(), 0);
         assert_eq!(writer.in_progress_rows(), 0);
+        assert_eq!(writer.memory_size(), 0);
         assert_eq!(writer.bytes_written(), 4); // Initial header
         writer.write(&batch).unwrap();
 
@@ -2833,17 +2834,20 @@ mod tests {
         let initial_size = writer.in_progress_size();
         assert!(initial_size > 0);
         assert_eq!(writer.in_progress_rows(), 5);
+        let initial_memory = writer.memory_size();
+        assert!(initial_memory > 0);
 
         // updated on second write
         writer.write(&batch).unwrap();
         assert!(writer.in_progress_size() > initial_size);
         assert_eq!(writer.in_progress_rows(), 10);
+        assert!(writer.memory_size() > initial_memory);
 
         // in progress tracking is cleared, but the overall data written is updated
         let pre_flush_bytes_written = writer.bytes_written();
         writer.flush().unwrap();
         assert_eq!(writer.in_progress_size(), 0);
-        assert_eq!(writer.in_progress_rows(), 0);
+        assert_eq!(writer.memory_size(), 0);
         assert!(writer.bytes_written() > pre_flush_bytes_written);
 
         writer.close().unwrap();

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -185,7 +185,21 @@ impl<W: Write + Send> ArrowWriter<W> {
         self.writer.flushed_row_groups()
     }
 
-    /// Returns the estimated length in bytes of the current in progress row group
+    /// Returns the estimated memory usage of the current in progress row group.
+    ///
+    /// This includes the current encoded size of written bytes, as well as
+    /// the size of the unencoded data not yet flushed.
+    pub fn memory_size(&self) -> usize {
+        match &self.in_progress {
+            Some(in_progress) => in_progress.writers.iter().map(|x| x.memory_size()).sum(),
+            None => 0,
+        }
+    }
+
+    /// Returns the estimated length in encoded bytes of the current in progress row group.
+    ///
+    /// This includes an estimate of any data that has not yet been flushed to a page,
+    /// based on it's anticipated encoded size.
     pub fn in_progress_size(&self) -> usize {
         match &self.in_progress {
             Some(in_progress) => in_progress
@@ -600,7 +614,21 @@ impl ArrowColumnWriter {
         Ok(ArrowColumnChunk { data, close })
     }
 
-    /// Returns the estimated total bytes for this column writer
+    /// Returns the estimated total memory usage.
+    ///
+    /// Unlike [`Self::get_estimated_total_bytes`] this is an estimate
+    /// of the current memory usage and not it's anticipated encoded size.
+    pub fn memory_size(&self) -> usize {
+        match &self.writer {
+            ArrowColumnWriterImpl::ByteArray(c) => c.memory_size(),
+            ArrowColumnWriterImpl::Column(c) => c.memory_size(),
+        }
+    }
+
+    /// Returns the estimated total encoded bytes for this column writer.
+    ///
+    /// This includes an estimate of any data that has not yet been flushed to a page,
+    /// based on it's anticipated encoded size.
     pub fn get_estimated_total_bytes(&self) -> usize {
         match &self.writer {
             ArrowColumnWriterImpl::ByteArray(c) => c.get_estimated_total_bytes() as _,

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -93,6 +93,9 @@ pub trait ColumnValueEncoder {
     /// Returns true if this encoder has a dictionary page
     fn has_dictionary(&self) -> bool;
 
+    /// Returns the estimated total memory usage of the encoder
+    fn estimated_memory_size(&self) -> usize;
+
     /// Returns an estimate of the dictionary page size in bytes, or `None` if no dictionary
     fn estimated_dict_page_size(&self) -> Option<usize>;
 
@@ -225,6 +228,15 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
 
     fn has_dictionary(&self) -> bool {
         self.dict_encoder.is_some()
+    }
+
+    fn estimated_memory_size(&self) -> usize {
+        match &self.dict_encoder {
+            Some(encoder) => encoder.estimated_memory_size(),
+            // TODO: for now, we are ignoring the memory overhead for unflushed data
+            // in the other encoders (besides DictEncoder)
+            _ => self.encoder.estimated_data_encoded_size(),
+        }
     }
 
     fn estimated_dict_page_size(&self) -> Option<usize> {

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -72,7 +72,13 @@ pub enum ColumnWriter<'a> {
 }
 
 impl<'a> ColumnWriter<'a> {
-    /// Returns the estimated total bytes for this column writer
+    /// Returns the estimated total memory usage
+    #[cfg(feature = "arrow")]
+    pub(crate) fn memory_size(&self) -> usize {
+        downcast_writer!(self, typed, typed.memory_size())
+    }
+
+    /// Returns the estimated total encoded bytes for this column writer
     #[cfg(feature = "arrow")]
     pub(crate) fn get_estimated_total_bytes(&self) -> u64 {
         downcast_writer!(self, typed, typed.get_estimated_total_bytes())
@@ -419,6 +425,15 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         )
     }
 
+    /// Returns the estimated total memory usage.
+    ///
+    /// Unlike [`Self::get_estimated_total_bytes`] this is an estimate
+    /// of the current memory usage and not it's anticipated encoded size.
+    #[cfg(feature = "arrow")]
+    pub(crate) fn memory_size(&self) -> usize {
+        todo!("TODO in next commit")
+    }
+
     /// Returns total number of bytes written by this column writer so far.
     /// This value is also returned when column writer is closed.
     ///
@@ -428,10 +443,11 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         self.column_metrics.total_bytes_written
     }
 
-    /// Returns the estimated total bytes for this column writer
+    /// Returns the estimated total encoded bytes for this column writer.
     ///
     /// Unlike [`Self::get_total_bytes_written`] this includes an estimate
-    /// of any data that has not yet been flushed to a page
+    /// of any data that has not yet been flushed to a page, based on it's
+    /// anticipated encoded size.
     #[cfg(feature = "arrow")]
     pub(crate) fn get_estimated_total_bytes(&self) -> u64 {
         self.column_metrics.total_bytes_written

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -431,7 +431,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     /// of the current memory usage and not it's anticipated encoded size.
     #[cfg(feature = "arrow")]
     pub(crate) fn memory_size(&self) -> usize {
-        todo!("TODO in next commit")
+        self.column_metrics.total_bytes_written as usize + self.encoder.estimated_memory_size()
     }
 
     /// Returns total number of bytes written by this column writer so far.

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -143,6 +143,11 @@ impl<T: DataType> DictEncoder<T> {
     fn bit_width(&self) -> u8 {
         num_required_bits(self.num_entries().saturating_sub(1) as u64)
     }
+
+    /// Returns the estimated total memory usage
+    pub(crate) fn estimated_memory_size(&self) -> usize {
+        self.interner.storage().size_in_bytes + self.indices.len() * 8
+    }
 }
 
 impl<T: DataType> Encoder<T> for DictEncoder<T> {


### PR DESCRIPTION
**For profiling only; branches off an iox-only base branch, not the apache base `master` branch. A separate upstream PR will be made for the actual change.**

# Which issue does this PR close?

This branch was made as part of the investigation into the datafusion memory tracking vs actual usage, as per https://github.com/influxdata/influxdb_iox/issues/11168. This PR adds 3 commits onto the current iox's arrow-rs base. Based upon the outcome of the tests shown below, we propose adding these 3 commits to an upstream PR.

These commits also fulfill the requested API change per https://github.com/apache/arrow-rs/issues/5851.

# Rationale for this change
 
We have several profiling test cases which compare datafusion's tracked [MemoryReservation](https://github.com/apache/datafusion/blob/2d1e8505eacc77137425cc0fed2076bdb6af91a0/datafusion/execution/src/memory_pool/mod.rs#L186)s with the actual peak memory usage. The largest single difference was in the tracking of memory used during the parquet encoding (via ArrowWriter). Here is a summary of the discrepancy per test case:

| Use case                       | root caller              | profiled heap peak (actual used) | peak reserved bytes (datafusion estimate) | difference (actual - estimate) |
| ------------------------------ | ------------------------ | -------------------------------- | ----------------------------------------- | ------------------------------ |
| test case 1, incl 61 columns   | TrackedMemoryArrowWriter | 798.9 MB                         | 49.4 MB                                   | -749.5 MB                      |
| test case 2, incl 4869 columns | TrackedMemoryArrowWriter | 4.1 GB                           | 220.1 MB                                  | -3.9 GB                        |
| test case 3, incl 1042 colums  | TrackedMemoryArrowWriter | 3.3 GB 	                       | 98.7 MB 	                               | -3.2 GB                        |

These^^ results provided significant motivation to fulfill the existing upstream feature request, to provide an ArrowWriter API for memory size used during encoding (refer to https://github.com/apache/arrow-rs/issues/5851). Currently, we have been reserving memory bytes based upon the anticipated encoded (compressed) size, as that was the only API available on the ArrowWriter. 

The changes in this PR introduce a new `memory_size()` API, defined as both the already encoded size plus the uncompressed/unflushed bytes in buffer. Next, we limited our accounting of unflushed bytes to [the DictEncoder](https://github.com/apache/arrow-rs/blob/0a4d8a14b58e45ef92e31541f0b51a5b25de5f10/parquet/src/encodings/encoding/dict_encoder.rs#L80), (although future PRs may expand this accounting). This change alone had a significant impact on our test case 3:

| Use case                        | root caller              | profiled heap peak (actual used) | peak reserved bytes (datafusion estimate) | difference (actual - estimate) |
| ------------------------------- | ------------------------ | -------------------------------- | ----------------------------------------- | ------------------------------ |
| test case 3, CONTROL            | TrackedMemoryArrowWriter | 3.3 GB 	                        | 98.7 MB 	                                | -3.2 GB                        |
| test case 3, WITH THESE CHANGES | TrackedMemoryArrowWriter | 3.3 GB                           | 2.2 GB                                    | -1.1 GB                        |

Accounting for the DictEncoder unflushed bytes has improved our memory tracking by ~2 GBs in this test case. We anticipate followup PRs which expand this `memory_size()` accounting to cover our other test cases as well.


# What changes are included in this PR?

* Delineate two APIs: the existing method for the anticipated encoded size, vs the new API for the memory size during encoding.
* Then implement the new memory to include accounting for unflushed DictEncoder bytes.

# Are there any user-facing changes?

Yes, the new `ArrowWriter::memory_size()` API.
