### PR TITLE
arrow 53.0.0 with downgraded tonic / prost

### DIFF
--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -313,6 +313,7 @@ mod tests {
     // More tests located in top-level arrow crate
 
     #[test]
+    #[allow(unused_must_use)]
     fn null_array_n_buffers() {
         let data = ArrayData::new_null(&DataType::Null, 10);
 

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -44,11 +44,11 @@ bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 once_cell = { version = "1", optional = true }
 paste = { version = "1.0" }
-prost = { version = "0.13.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.12.3", default-features = false, features = ["prost-derive"] }
 # For Timestamp type
-prost-types = { version = "0.13.1", default-features = false }
+prost-types = { version = "0.12.3", default-features = false }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "rt-multi-thread"] }
-tonic = { version = "0.12.1", default-features = false, features = ["transport", "codegen", "prost"] }
+tonic = { version = "0.11.0", default-features = false, features = ["transport", "codegen", "prost"] }
 
 # CLI-related dependencies
 anyhow = { version = "1.0", optional = true }
@@ -70,9 +70,8 @@ cli = ["anyhow", "arrow-cast/prettyprint", "clap", "tracing-log", "tracing-subsc
 [dev-dependencies]
 arrow-cast = { workspace = true, features = ["prettyprint"] }
 assert_cmd = "2.0.8"
-http = "1.1.0"
-http-body = "1.0.0"
-hyper-util = "0.1"
+http = "0.2.9"
+http-body = "0.4.5"
 pin-project-lite = "0.2"
 tempfile = "3.3"
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -791,8 +791,7 @@ impl ProstMessageExt for FetchResults {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::{TryFutureExt, TryStreamExt};
-    use hyper_util::rt::TokioIo;
+    use futures::TryStreamExt;
     use std::fs;
     use std::future::Future;
     use std::net::SocketAddr;
@@ -852,8 +851,7 @@ mod tests {
             .serve_with_incoming(stream);
 
         let request_future = async {
-            let connector =
-                service_fn(move |_| UnixStream::connect(path.clone()).map_ok(TokioIo::new));
+            let connector = service_fn(move |_| UnixStream::connect(path.clone()));
             let channel = Endpoint::try_from("http://example.com")
                 .unwrap()
                 .connect_with_connector(connector)

--- a/arrow-flight/gen/Cargo.toml
+++ b/arrow-flight/gen/Cargo.toml
@@ -33,5 +33,5 @@ publish = false
 # Pin specific version of the tonic-build dependencies to avoid auto-generated
 # (and checked in) arrow.flight.protocol.rs from changing
 proc-macro2 = { version = "=1.0.86", default-features = false }
-prost-build = { version = "=0.13.1", default-features = false }
-tonic-build = { version = "=0.12.2", default-features = false, features = ["transport", "prost"] }
+prost-build = { version = "=0.12.6", default-features = false }
+tonic-build = { version = "=0.11.0", default-features = false, features = ["transport", "prost"] }

--- a/arrow-flight/src/sql/arrow.flight.protocol.sql.rs
+++ b/arrow-flight/src/sql/arrow.flight.protocol.sql.rs
@@ -101,7 +101,7 @@ pub struct CommandGetSqlInfo {
 /// >
 /// The returned data should be ordered by data_type and then by type_name.
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommandGetXdbcTypeInfo {
     ///
     /// Specifies the data type to search for the info.
@@ -121,7 +121,7 @@ pub struct CommandGetXdbcTypeInfo {
 /// >
 /// The returned data should be ordered by catalog_name.
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommandGetCatalogs {}
 ///
 /// Represents a request to retrieve the list of database schemas on a Flight SQL enabled backend.
@@ -232,7 +232,7 @@ pub struct CommandGetTables {
 /// >
 /// The returned data should be ordered by table_type.
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommandGetTableTypes {}
 ///
 /// Represents a request to retrieve the primary keys of a table on a Flight SQL enabled backend.
@@ -511,7 +511,7 @@ pub struct ActionClosePreparedStatementRequest {
 /// Request message for the "BeginTransaction" action.
 /// Begins a transaction.
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ActionBeginTransactionRequest {}
 ///
 /// Request message for the "BeginSavepoint" action.
@@ -839,7 +839,7 @@ pub struct CommandStatementIngest {
 pub mod command_statement_ingest {
     /// Options for table definition behavior
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, Copy, PartialEq, ::prost::Message)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct TableDefinitionOptions {
         #[prost(
             enumeration = "table_definition_options::TableNotExistOption",
@@ -950,7 +950,7 @@ pub mod command_statement_ingest {
 /// CommandPreparedStatementUpdate, or CommandStatementIngest was
 /// in the request, containing results from the update.
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DoPutUpdateResult {
     /// The number of records updated. A return value of -1 represents
     /// an unknown updated record count.
@@ -1010,7 +1010,7 @@ pub struct ActionCancelQueryRequest {
 /// This command is deprecated since 13.0.0. Use the "CancelFlightInfo"
 /// action with DoAction instead.
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ActionCancelQueryResult {
     #[prost(enumeration = "action_cancel_query_result::CancelResult", tag = "1")]
     pub result: i32,

--- a/arrow-integration-testing/Cargo.toml
+++ b/arrow-integration-testing/Cargo.toml
@@ -42,11 +42,11 @@ async-trait = { version = "0.1.41", default-features = false }
 clap = { version = "4", default-features = false, features = ["std", "derive", "help", "error-context", "usage"] }
 futures = { version = "0.3", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["std"] }
-prost = { version = "0.13", default-features = false }
+prost = { version = "0.12", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["rc", "derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 tokio = { version = "1.0", default-features = false }
-tonic = { version = "0.12", default-features = false }
+tonic = { version = "0.11", default-features = false }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["fmt"], optional = true }
 num = { version = "0.4", default-features = false, features = ["std"] }
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -2559,6 +2559,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn test_decimal128_alignment16_is_sufficient() {
         const IPC_ALIGNMENT: usize = 16;
 
@@ -2618,6 +2619,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn test_decimal128_alignment8_is_unaligned() {
         const IPC_ALIGNMENT: usize = 8;
 
@@ -2675,6 +2677,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn test_flush() {
         // We write a schema which is small enough to fit into a buffer and not get flushed,
         // and then force the write with .flush().

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -402,6 +402,7 @@ fn sort_fixed_size_list(
     Ok(sort_impl(options, &mut valids, &null_indices, limit, Ord::cmp).into())
 }
 
+#[allow(clippy::needless_maybe_sized)]
 #[inline(never)]
 fn sort_impl<T: ?Sized + Copy>(
     options: SortOptions,

--- a/arrow-schema/src/fields.rs
+++ b/arrow-schema/src/fields.rs
@@ -387,6 +387,7 @@ impl UnionFields {
     {
         let fields = fields.into_iter().map(Into::into);
         let mut set = 0_u128;
+        #[allow(clippy::manual_inspect)]
         type_ids
             .into_iter()
             .map(|idx| {

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -3034,6 +3034,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::byte_char_slices)]
     fn test_disabled_statistics_with_page() {
         let file_schema = Schema::new(vec![
             Field::new("a", DataType::Utf8, true),
@@ -3106,6 +3107,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::byte_char_slices)]
     fn test_disabled_statistics_with_chunk() {
         let file_schema = Schema::new(vec![
             Field::new("a", DataType::Utf8, true),

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -1297,6 +1297,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::byte_char_slices)]
     fn test_byte_array_from() {
         assert_eq!(
             ByteArray::from(vec![b'A', b'B', b'C']).data(),

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -55,6 +55,7 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
         // write offset index to the file
         for (row_group_idx, row_group) in self.row_groups.iter_mut().enumerate() {
             for (column_idx, column_metadata) in row_group.columns.iter_mut().enumerate() {
+                #[allow(clippy::single_match)]
                 match &offset_indexes[row_group_idx][column_idx] {
                     Some(offset_index) => {
                         let start_offset = self.buf.bytes_written();
@@ -84,6 +85,7 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
         // write column index to the file
         for (row_group_idx, row_group) in self.row_groups.iter_mut().enumerate() {
             for (column_idx, column_metadata) in row_group.columns.iter_mut().enumerate() {
+                #[allow(clippy::single_match)]
                 match &column_indexes[row_group_idx][column_idx] {
                     Some(column_index) => {
                         let start_offset = self.buf.bytes_written();

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -294,6 +294,7 @@ impl<'a> PrimitiveTypeBuilder<'a> {
             ));
         }
 
+        #[allow(clippy::single_match)]
         match &self.logical_type {
             Some(logical_type) => {
                 // If a converted type is populated, check that it is consistent with


### PR DESCRIPTION
Related to  https://github.com/influxdata/influxdb_iox/issues/12409

I don't intend to merge this PR, but am using it as a place to document what is on the `53.0.0-downgraded-tonic` branch

# Rationale
arrow-flight 53.0.0 upgrades  tonic to 0.12 which requires a newer version of hyper than we currently use

We would like to decouple our DataFusion upgrade from the larger hyper upgrade described in https://github.com/influxdata/influxdb_iox/issues/9340

# Changes
- Downgrade tonic used in arrow-flight back to 0.11 (by reverting  741bbf6 / https://github.com/apache/arrow-rs/pull/6041) temporily
